### PR TITLE
feat(plot): auto zoom plot when unconverged observations exist

### DIFF
--- a/BayesOpt4dftu/common/configuration.py
+++ b/BayesOpt4dftu/common/configuration.py
@@ -69,6 +69,7 @@ class Config:
         self.report_optimum_interval = bo_params.get('report_optimum_interval', 10)
         self.threshold_opt_u = bo_params.get('threshold_opt_u', 0.0)
         self.print_magmom = bo_params.get('print_magmom', False)
+        self.zoom_threshold = bo_params.get('zoom_threshold', 2.0)
 
         # File paths
         self.root_dir = './'

--- a/BayesOpt4dftu/core/bo.py
+++ b/BayesOpt4dftu/core/bo.py
@@ -107,9 +107,10 @@ class BoStepExecutor(OptimizerGenerator):
     _logger = BoLoggerGenerator.get_logger("BoStepExecutor")
 
     def __init__(self, utxt_path, column_names, opt_u_index, u_range, alpha_gap, alpha_band, alpha_mag, kappa,
-                 elements):
+                 elements, zoom_threshold=2.0):
         super().__init__(utxt_path, column_names, opt_u_index, u_range, alpha_gap, alpha_band, alpha_mag, kappa)
         self._elements: List[str] = elements
+        self._zoom_threshold: float = zoom_threshold
         self._optimizer: Optional[BayesianOptimization] = None
         self._target: Optional[float] = None
         self._optimal: Optional[Tuple[Any, Any]] = None
@@ -201,59 +202,104 @@ class BoStepExecutor(OptimizerGenerator):
             opt_eles = [ele for i, ele in enumerate(self._elements) if self._opt_u_index[i]]
             d = self._plot_data
             if self._dim == 1:
-                fig = plt.figure()
-                gs = gridspec.GridSpec(2, 1)
-                axis = plt.subplot(gs[0])
-                acq = plt.subplot(gs[1])
-                axis.plot(d['x_obs'].flatten(), d['y_obs'], 'D', markersize=8, label=u'Observations', color='r')
-                axis.plot(d['x'], d['mu'], '--', color='k', label='Prediction')
-                axis.fill(np.concatenate([d['x'], d['x'][::-1]]),
-                          np.concatenate([d['mu'] - 1.9600 * d['sigma'], (d['mu'] + 1.9600 * d['sigma'])[::-1]]),
-                          alpha=.6, fc='c', ec='None', label='95% confidence interval')
-
-                axis.set_xlim(self._u_range)
-                axis.set_ylim((None, None))
-                axis.set_ylabel('f(x)')
-
                 utility = self._utility_function.utility(d['x'], self._optimizer._gp, 0)
-                acq.plot(d['x'], utility, label='Acquisition Function', color='purple')
-                acq.plot(d['x'][np.argmax(utility)], np.max(utility), '*', markersize=15,
-                         label=u'Next Best Guess', markerfacecolor='gold', markeredgecolor='k', markeredgewidth=1)
-                acq.set_xlim(self._u_range)
-                acq.set_ylim((np.min(utility) - 0.5, np.max(utility) + 0.5))
-                acq.set_ylabel('Acquisition')
-                acq.set_xlabel('U (eV)')
-                axis.legend(loc=4, borderaxespad=0.)
-                acq.legend(loc=4, borderaxespad=0.)
+                base = f"1D_kappa_{self._kappa}_ag_{self._alpha_gap}_ab_{self._alpha_band}_am_{self._alpha_mag}"
+                x_obs_flat = d['x_obs'].flatten()
+                y_obs = d['y_obs']
 
-                plt.savefig(
-                    f"1D_kappa_{self._kappa}_ag_{self._alpha_gap}_ab_{self._alpha_band}_am_{self._alpha_mag}.png",
-                    dpi=400)
+                # Decide whether to produce zoom plot
+                if y_obs.max() - y_obs.min() > self._zoom_threshold:
+                    # Zoom: x-range of obs within 0.3 of best, y-range of those obs
+                    cutoff = y_obs.max() - 0.3
+                    good_mask = y_obs >= cutoff
+                    good_x = x_obs_flat[good_mask]
+                    good_y = y_obs[good_mask]
+                    span = max(good_x.max() - good_x.min(), 1.0)
+                    zoom_xlim = (float(good_x.min() - 0.1 * span), float(good_x.max() + 0.1 * span))
+                    y_pad = max(0.1 * (good_y.max() - good_y.min()), 0.05)
+                    zoom_ylim = (float(good_y.min() - y_pad), float(good_y.max() + y_pad))
+                    plot_configs = [
+                        (f"{base}_full.png", tuple(self._u_range), None),
+                        (f"{base}_zoom.png", zoom_xlim, zoom_ylim),
+                    ]
+                else:
+                    plot_configs = [(f"{base}.png", tuple(self._u_range), None)]
+
+                acq_ylim = (np.min(utility) - 0.5, np.max(utility) + 0.5)
+                for fname, xlim, fx_ylim in plot_configs:
+                    fig = plt.figure()
+                    gs = gridspec.GridSpec(2, 1)
+                    axis = plt.subplot(gs[0])
+                    acq = plt.subplot(gs[1])
+                    axis.plot(x_obs_flat, y_obs, 'D', markersize=8, label=u'Observations', color='r')
+                    axis.plot(d['x'], d['mu'], '--', color='k', label='Prediction')
+                    axis.fill(np.concatenate([d['x'], d['x'][::-1]]),
+                              np.concatenate([d['mu'] - 1.9600 * d['sigma'], (d['mu'] + 1.9600 * d['sigma'])[::-1]]),
+                              alpha=.6, fc='c', ec='None', label='95% confidence interval')
+                    axis.set_xlim(xlim)
+                    if fx_ylim is not None:
+                        axis.set_ylim(fx_ylim)
+                    axis.set_ylabel('f(x)')
+
+                    acq.plot(d['x'], utility, label='Acquisition Function', color='purple')
+                    acq.plot(d['x'][np.argmax(utility)], np.max(utility), '*', markersize=15,
+                             label=u'Next Best Guess', markerfacecolor='gold', markeredgecolor='k', markeredgewidth=1)
+                    acq.set_xlim(xlim)
+                    acq.set_ylim(acq_ylim)
+                    acq.set_ylabel('Acquisition')
+                    acq.set_xlabel('U (eV)')
+                    axis.legend(loc=4, borderaxespad=0.)
+                    acq.legend(loc=4, borderaxespad=0.)
+
+                    plt.savefig(fname, dpi=400)
+                    plt.close(fig)
 
             elif self._dim == 2:
-                fig, axis = plt.subplots(1, 2, figsize=(15, 5))
-                plt.subplots_adjust(wspace=0.2)
-
-                axis[0].plot(d['x1_obs'], d['x2_obs'], 'D', markersize=4, color='k', label='Observations')
-                axis[0].set_title('Gaussian Process Predicted Mean', pad=10)
-                im1 = axis[0].hexbin(d['x'], d['y'], C=d['mu'], cmap=cm.jet, bins=None)
-                axis[0].axis([d['x'].min(), d['x'].max(), d['y'].min(), d['y'].max()])
-                axis[0].set_xlabel(r'U_%s (eV)' % opt_eles[0], labelpad=5)
-                axis[0].set_ylabel(r'U_%s (eV)' % opt_eles[1], labelpad=10, va='center')
-                cbar1 = plt.colorbar(im1, ax=axis[0])
-
                 utility = self._utility_function.utility(d['X'], self._optimizer._gp, self._optimizer.max)
-                axis[1].plot(d['x1_obs'], d['x2_obs'], 'D', markersize=4, color='k', label='Observations')
-                axis[1].set_title('Acquisition Function', pad=10)
-                axis[1].set_xlabel(r'U_%s (eV)' % opt_eles[0], labelpad=5)
-                axis[1].set_ylabel(r'U_%s (eV)' % opt_eles[1], labelpad=10, va='center')
-                im2 = axis[1].hexbin(d['x'], d['y'], C=utility, cmap=cm.jet, bins=None)
-                axis[1].axis([d['x'].min(), d['x'].max(), d['y'].min(), d['y'].max()])
-                cbar2 = plt.colorbar(im2, ax=axis[1])
+                base = f"2D_kappa_{self._kappa}_ag_{self._alpha_gap}_ab_{self._alpha_band}_am_{self._alpha_mag}"
+                x1_obs = d['x1_obs'].flatten()
+                x2_obs = d['x2_obs'].flatten()
+                y_obs_2d = np.array([res["target"] for res in self._optimizer.res])
+                full_axis = [d['x'].min(), d['x'].max(), d['y'].min(), d['y'].max()]
 
-                plt.savefig(
-                    f"2D_kappa_{self._kappa}_ag_{self._alpha_gap}_ab_{self._alpha_band}_am_{self._alpha_mag}.png",
-                    dpi=400)
+                if y_obs_2d.max() - y_obs_2d.min() > self._zoom_threshold:
+                    cutoff_2d = y_obs_2d.max() - 0.3
+                    good_2d = y_obs_2d >= cutoff_2d
+                    span_x = max(x1_obs[good_2d].max() - x1_obs[good_2d].min(), 1.0)
+                    span_y = max(x2_obs[good_2d].max() - x2_obs[good_2d].min(), 1.0)
+                    zoom_axis = [float(x1_obs[good_2d].min() - 0.1 * span_x),
+                                 float(x1_obs[good_2d].max() + 0.1 * span_x),
+                                 float(x2_obs[good_2d].min() - 0.1 * span_y),
+                                 float(x2_obs[good_2d].max() + 0.1 * span_y)]
+                    plot_configs_2d = [
+                        (f"{base}_full.png", full_axis),
+                        (f"{base}_zoom.png", zoom_axis),
+                    ]
+                else:
+                    plot_configs_2d = [(f"{base}.png", full_axis)]
+
+                for fname, ax_range in plot_configs_2d:
+                    fig, axis = plt.subplots(1, 2, figsize=(15, 5))
+                    plt.subplots_adjust(wspace=0.2)
+
+                    axis[0].plot(d['x1_obs'], d['x2_obs'], 'D', markersize=4, color='k', label='Observations')
+                    axis[0].set_title('Gaussian Process Predicted Mean', pad=10)
+                    im1 = axis[0].hexbin(d['x'], d['y'], C=d['mu'], cmap=cm.jet, bins=None)
+                    axis[0].axis(ax_range)
+                    axis[0].set_xlabel(r'U_%s (eV)' % opt_eles[0], labelpad=5)
+                    axis[0].set_ylabel(r'U_%s (eV)' % opt_eles[1], labelpad=10, va='center')
+                    plt.colorbar(im1, ax=axis[0])
+
+                    axis[1].plot(d['x1_obs'], d['x2_obs'], 'D', markersize=4, color='k', label='Observations')
+                    axis[1].set_title('Acquisition Function', pad=10)
+                    axis[1].set_xlabel(r'U_%s (eV)' % opt_eles[0], labelpad=5)
+                    axis[1].set_ylabel(r'U_%s (eV)' % opt_eles[1], labelpad=10, va='center')
+                    im2 = axis[1].hexbin(d['x'], d['y'], C=utility, cmap=cm.jet, bins=None)
+                    axis[1].axis(ax_range)
+                    plt.colorbar(im2, ax=axis[1])
+
+                    plt.savefig(fname, dpi=400)
+                    plt.close(fig)
 
         else:
             self._logger.info("Figure generation omitted for U value optimization with dimensions >= 3.")
@@ -276,7 +322,7 @@ class BoDftuIterator(BoStepExecutor):
         super().__init__(upath, self._config.column_names,
                          self._config.which_u, self._config.urange,
                          self._config.alpha_gap, self._config.alpha_band, self._config.alpha_mag, self._config.k,
-                         self._config.elements)
+                         self._config.elements, self._config.zoom_threshold)
         self._logger.info("Bayesian Optimization begins.")
         self._i_step: int = 0
         self._obj_last: Optional[float] = None

--- a/README.md
+++ b/README.md
@@ -63,8 +63,14 @@ bo_dftu
 Upon reaching the threshold or maximum iterations, two output files are generated:
 
 - `u_xxx.txt`/`formatted_u_xxx.txt`: Contains U parameters, band gap, Δgap, Δband, and Δmagnetization (optional) for each iteration.
-- `1D_xxx.png` or `2D_xxx.png`: Provides a visual representation of the Gaussian process predicted mean and acquisition function. 
+- `1D_xxx.png` or `2D_xxx.png`: Provides a visual representation of the Gaussian process predicted mean and acquisition function.
    This file will be omitted if you set three or more optimizable U parameters.
+
+**Automatic zoom plot**: When the range of observed objective values exceeds `zoom_threshold` (default: `2.0`), two plots are generated instead of one:
+- `1D_xxx_full.png` / `2D_xxx_full.png`: Full U range, identical to the original single plot.
+- `1D_xxx_zoom.png` / `2D_xxx_zoom.png`: Automatically cropped to the region of well-converged observations (within 0.3 of the best objective value), with the y-axis scaled to that region. This is useful when some BO iterations explore U values where DFT+U fails to open a band gap, producing strongly negative objective values that compress the full plot and make the converged region hard to read.
+
+If all observations are well-behaved (objective range ≤ `zoom_threshold`), only the original single plot is produced.
 
 **Example of BO plots**:
 
@@ -183,6 +189,10 @@ Before running the program, configure the `input.json` file. It contains:
     - **`print_magmom`**:
         - **Description**: Specifies whether to print the magnetic moment at each iteration.
         - **Default**: `"print_magmom": false`
+
+    - **`zoom_threshold`**:
+        - **Description**: When the range of observed objective values (max − min) exceeds this value, an additional zoom plot (`*_zoom.png`) is generated alongside the full plot (`*_full.png`). The zoom plot crops the x-axis to observations within 0.3 of the best objective value and scales the y-axis to that region. Set to `0.0` to always produce zoom plots, or to a very large value to disable them.
+        - **Default**: `"zoom_threshold": 2.0`
 
 - **`structure_info`** : Includes geometry information (such as lattice parameter, lattice vectors, atomic position,
   etc.) of the target materials.


### PR DESCRIPTION
## Summary

- When the BO explores U values where DFT+U fails to open a band gap, the resulting strongly negative objective values compress the full plot and make the converged region hard to read.
- Added an **automatic zoom plot** that is generated alongside the full plot whenever this situation is detected.

## How it works

- If `max(obj) - min(obj) > zoom_threshold` (default `2.0`): generates both `*_full.png` (original) and `*_zoom.png` (cropped to well-converged region)
- If all observations are well-behaved: generates only the original single plot — **no change to existing behavior**
- Zoom x-range: observations within 0.3 of the best objective value
- Zoom y-axis: scaled to those good observations, clipping any bad dips for a clean view
- `zoom_threshold` is configurable in `input.json` under the `bo` section

## Example

The full plot (left) shows the complete U range including unconverged regions. The zoom plot (right) automatically crops to the converged region for a clean, publication-ready view.

<!-- Please drag and drop the full and zoom plot images here -->
<img width="2560" height="1920" alt="1D_kappa_5 0_ag_0 0_ab_0 5_am_0 5_full" src="https://github.com/user-attachments/assets/9b4ab305-3199-4e00-85b2-f62c07d77773" />
<img width="2560" height="1920" alt="1D_kappa_5 0_ag_0 0_ab_0 5_am_0 5_zoom" src="https://github.com/user-attachments/assets/559d4226-cd44-4686-ba53-99bbdb6db3ba" />


## Changes

- `BayesOpt4dftu/core/bo.py`: zoom plot logic in `plot()`
- `BayesOpt4dftu/common/configuration.py`: add `zoom_threshold` parameter
- `README.md`: document the new feature and parameter